### PR TITLE
feat(github): add issue templates for bug reports, features, and ques…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## 🐛 Bug Description
+
+A clear and concise description of what the bug is.
+
+## 🔄 Steps to Reproduce
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## ✅ Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## ❌ Actual Behavior
+
+A clear and concise description of what actually happened.
+
+## 📸 Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## 🌍 Environment
+
+- **OS**: [e.g. macOS 14.0, Ubuntu 22.04]
+- **Browser** (if applicable): [e.g. Chrome 120, Firefox 121]
+- **Kubernetes Version**: [e.g. v1.28.0]
+- **Tron Version**: [e.g. v1.0.0]
+
+## 📋 Additional Context
+
+Add any other context about the problem here.
+
+## 🔍 Logs
+
+If applicable, add relevant logs or error messages:
+
+```
+Paste logs here
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📚 Documentation
+    url: https://github.com/grid-labs-tech/tron#readme
+    about: Check the README and documentation for common questions
+  - name: 💬 Discussions
+    url: https://github.com/grid-labs-tech/tron/discussions
+    about: Ask questions and discuss ideas with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,43 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## 🚀 Feature Description
+
+A clear and concise description of the feature you'd like to see.
+
+## 💡 Motivation
+
+Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## 🎯 Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+## 🔄 Alternatives Considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## 📋 Additional Context
+
+Add any other context, mockups, or screenshots about the feature request here.
+
+## 🎨 UI/UX Considerations
+
+If this feature involves UI/UX changes, please describe:
+- What screens/pages are affected?
+- What user interactions are involved?
+- Any design mockups or wireframes?
+
+## 🔧 Technical Considerations
+
+If you have technical insights, please describe:
+- API changes needed?
+- Database schema changes?
+- Kubernetes resources involved?
+- Performance implications?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,31 @@
+---
+name: Question
+about: Ask a question about the project
+title: '[QUESTION] '
+labels: question
+assignees: ''
+---
+
+## ❓ Question
+
+Your question here.
+
+## 📋 Context
+
+Provide any relevant context about your question:
+- What are you trying to accomplish?
+- What have you tried so far?
+- Any relevant code snippets or configurations?
+
+## 🔍 Environment
+
+- **OS**: [e.g. macOS 14.0, Ubuntu 22.04]
+- **Kubernetes Version**: [e.g. v1.28.0]
+- **Tron Version**: [e.g. v1.0.0]
+
+## 📚 Documentation Checked
+
+- [ ] I've checked the README
+- [ ] I've checked the API documentation
+- [ ] I've searched existing issues
+- [ ] I've searched discussions


### PR DESCRIPTION
feat(github): add issue templates for bug reports, features, and questions

Add GitHub issue templates to standardize issue creation and improve
information collection. Includes:

- Bug report template with environment details and reproduction steps
- Feature request template with technical and UI/UX considerations
- Question template with documentation checklist
- Config file to disable blank issues and add contact links

This improves issue quality and makes it easier to triage and respond
to issues effectively.