### PR TITLE
fix(ci): add security-events permission to security scan job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,6 +243,9 @@ jobs:
     name: Security Scan
     needs: changes
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.portal == 'true'
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code
@@ -260,6 +263,7 @@ jobs:
       - name: Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@v3
         if: always()
+        continue-on-error: true
         with:
           sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
## Summary
- Add `security-events: write` permission to security-scan job
- Add `continue-on-error: true` to SARIF upload step

## Problem
The security scan job was failing because it lacked the required permission to upload SARIF results to GitHub's security tab. This was causing the entire test workflow to fail even though all actual tests passed.

## Solution
Added the necessary permission and made the SARIF upload non-blocking so that:
1. On the main repo, security results will be uploaded properly
2. On forks or PRs with limited permissions, the job won't fail

## Test plan
- [ ] CI workflow passes
- [ ] Security scan results appear in Security tab (when applicable)