### PR TITLE
fix(ci): remove job-level permissions from reusable workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,9 +243,6 @@ jobs:
     name: Security Scan
     needs: changes
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.portal == 'true'
-    permissions:
-      contents: read
-      security-events: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Remove job-level permissions from security-scan job in tests.yml

## Problem
The previous fix (PR #31) added `permissions` to the security-scan job, which causes `startup_failure` when the workflow is called as a reusable workflow from release workflows.

## Solution
- Remove job-level permissions from security-scan job
- Keep `continue-on-error: true` for graceful SARIF upload handling

## Test plan
- [ ] CI tests pass
- [ ] Release workflows can start successfully