### PR TITLE
fix(portal): fix application creation form validation

### DIFF
--- a/portal/src/features/applications/schemas.ts
+++ b/portal/src/features/applications/schemas.ts
@@ -2,7 +2,10 @@ import { z } from 'zod'
 
 export const applicationCreateSchema = z.object({
   name: z.string().min(1, 'Application name is required').max(100, 'Name must be less than 100 characters'),
-  repository: z.string().url('Invalid repository URL').nullable().optional().or(z.literal('')),
+  repository: z.union([
+    z.string().url('Invalid repository URL'),
+    z.literal(''),
+  ]).nullish(),
   enabled: z.boolean().optional().default(true),
 })
 


### PR DESCRIPTION
## Summary

Fix the Create Application form that was not submitting when clicking the "Create Application" button.

## Root Cause

The `repository` field schema in `applicationCreateSchema` was incorrectly configured for Zod 4. When the repository field was left empty (which is valid since it's optional), the validation chain failed silently.

## Changes

**Before:**
```typescript
repository: z.string().url('Invalid repository URL').nullable().optional().or(z.literal('')),
```

**After:**
```typescript
repository: z.union([
  z.string().url('Invalid repository URL'),
  z.literal(''),
]).nullish(),
```

The new schema correctly handles:
- Valid URLs (e.g., `https://github.com/user/repo`)
- Empty strings (user leaves field blank)
- `null` values
- `undefined` values

## Test plan

- [x] Tested locally - form now submits correctly
- [x] Application is created
- [x] Redirects to instance detail page
- [ ] CI passes

Fixes #41