### PR TITLE
fix(k8s): correct Gateway API configuration for Traefik

### DIFF
--- a/docker/manifests/01-gateway.yaml
+++ b/docker/manifests/01-gateway.yaml
@@ -1,27 +1,20 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-  name: gatewayclass
-spec:
-  controllerName: traefik.io/gateway-controller
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway
   namespace: kube-system
 spec:
-  gatewayClassName: gatewayclass
+  gatewayClassName: traefik
   listeners:
-    - name: http
+    - name: web
       protocol: HTTP
-      port: 80
+      port: 8000
       allowedRoutes:
         namespaces:
           from: All
-    - name: https
+    - name: websecure
       protocol: HTTPS
-      port: 443
+      port: 8443
       allowedRoutes:
         namespaces:
           from: All

--- a/docker/manifests/traefik.yaml
+++ b/docker/manifests/traefik.yaml
@@ -25,6 +25,8 @@ spec:
       kubernetesIngress:
         publishedService:
           enabled: true
+      kubernetesGateway:
+        enabled: true
     priorityClassName: "system-cluster-critical"
     image:
       repository: "rancher/mirrored-library-traefik"


### PR DESCRIPTION
## Summary

Fix Gateway API configuration to work correctly with Traefik in the K3s development environment.

## Changes

### traefik.yaml
- Enable kubernetesGateway provider in Traefik Helm values

### 01-gateway.yaml
- Use traefik GatewayClass (auto-created by Traefik when kubernetesGateway is enabled)
- Update listener ports to match Traefik entryPoints:
  - web (HTTP): port 8000
  - websecure (HTTPS): port 8443
- Remove custom GatewayClass definition (no longer needed)

## Problem

The Gateway API was not working because:
1. Traefik kubernetesGateway provider was not enabled
2. The custom GatewayClass was not being recognized by Traefik
3. The Gateway listener ports (80/443) did not match Traefik entryPoints (8000/8443)

## Testing

```bash
# Start development environment
make start

# Wait for k3s to be ready, then test HTTP
curl -H "Host: test-app.localhost" http://localhost:8080

# Test HTTPS
curl -k -H "Host: test-app.localhost" https://localhost:8443
```

## Port Mapping

| Host Port | K3s Port | Traefik EntryPoint |
|-----------|----------|-------------------|
| 8080 | 80 | web (8000) |
| 8443 | 443 | websecure (8443) |