### PR TITLE
fix(portal): remove API Address column from clusters list

### DIFF
--- a/portal/src/pages/clusters/Clusters.tsx
+++ b/portal/src/pages/clusters/Clusters.tsx
@@ -225,11 +225,6 @@ function Clusters() {
             ),
           },
           {
-            key: 'api_address',
-            label: 'API Address',
-            render: (cluster) => <div className="text-sm text-slate-600">{cluster.api_address}</div>,
-          },
-          {
             key: 'environment',
             label: 'Environment',
             render: (cluster) => (


### PR DESCRIPTION
## Summary

Remove the API Address column from the clusters table to reduce visual clutter.

## Changes

- Removed API Address column from DataTable
- API Address remains accessible in the Edit modal

## Reason

The API Address is sensitive information and takes up space in the table. Users can still view and edit it through the Edit action.