### PR TITLE
fix(portal): remove create account link from login page

### DIFF
--- a/portal/src/pages/Login.tsx
+++ b/portal/src/pages/Login.tsx
@@ -151,15 +151,6 @@ export default function Login() {
               <span>Sign In</span>
             </button>
           </form>
-
-          <div className="mt-6 text-center">
-            <p className="text-sm text-neutral-600">
-              Don't have an account?{' '}
-              <Link to="/register" className="text-primary-600 hover:text-primary-700 font-medium">
-                Create account
-              </Link>
-            </p>
-          </div>
         </div>
 
         {/* Footer */}


### PR DESCRIPTION
## Summary

Remove the "Don't have an account? Create account" link from the login page.

## Reason

The self-registration option doesn't make sense for an open-source self-hosted platform. Users should be created by:
- Administrators through the Users page
- Via the initial setup wizard (first admin)

## Test plan

- [x] Login page renders without create account link
- [x] Lint passes