### PR TITLE
fix(api): use permissive email validation for self-hosted environments

### DIFF
--- a/api/app/auth/api/auth_dto.py
+++ b/api/app/auth/api/auth_dto.py
@@ -1,5 +1,10 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, field_validator
 from typing import Optional
+
+from app.shared.utils.validators import (
+    validate_email_permissive,
+    validate_email_optional,
+)
 
 
 class Token(BaseModel):
@@ -13,8 +18,13 @@ class TokenData(BaseModel):
 
 
 class LoginRequest(BaseModel):
-    email: EmailStr
+    email: str
     password: str
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        return validate_email_permissive(v)
 
 
 class RefreshTokenRequest(BaseModel):
@@ -22,7 +32,12 @@ class RefreshTokenRequest(BaseModel):
 
 
 class UpdateProfileRequest(BaseModel):
-    email: Optional[EmailStr] = None
+    email: Optional[str] = None
     full_name: Optional[str] = None
     password: Optional[str] = None
     current_password: Optional[str] = None  # Required to change password
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: Optional[str]) -> Optional[str]:
+        return validate_email_optional(v)

--- a/api/app/setup/api/setup_dto.py
+++ b/api/app/setup/api/setup_dto.py
@@ -1,6 +1,8 @@
 """DTOs for setup endpoints."""
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, Field, field_validator
+
+from app.shared.utils.validators import validate_email_permissive
 
 
 class SetupStatus(BaseModel):
@@ -13,13 +15,18 @@ class SetupStatus(BaseModel):
 class SetupInitialize(BaseModel):
     """Request to initialize the system."""
 
-    admin_email: EmailStr = Field(..., description="Admin user email")
+    admin_email: str = Field(..., description="Admin user email")
     admin_password: str = Field(..., min_length=6, description="Admin user password")
     admin_name: str = Field(default="Administrator", description="Admin user full name")
     # Kept for backward compatibility with older frontend versions
     organization_name: str = Field(
         default="", description="Organization name (not used)"
     )
+
+    @field_validator("admin_email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        return validate_email_permissive(v)
 
 
 class SetupInitializeResponse(BaseModel):

--- a/api/app/shared/utils/validators.py
+++ b/api/app/shared/utils/validators.py
@@ -1,0 +1,47 @@
+"""Shared validation utilities."""
+
+import re
+from typing import Optional
+
+
+def validate_email_permissive(email: str) -> str:
+    """
+    Validate email format with permissive rules for self-hosted environments.
+
+    This validator allows local/internal domains like:
+    - .local, .localhost, .internal, .corp, .lan, .test
+
+    These domains are commonly used in corporate/self-hosted environments
+    but rejected by strict email validators like Pydantic's EmailStr.
+
+    Args:
+        email: Email address to validate
+
+    Returns:
+        Lowercase email if valid
+
+    Raises:
+        ValueError: If email format is invalid
+    """
+    pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+    if not re.match(pattern, email):
+        raise ValueError("Invalid email format")
+    return email.lower()
+
+
+def validate_email_optional(email: Optional[str]) -> Optional[str]:
+    """
+    Validate optional email field.
+
+    Args:
+        email: Email address to validate or None
+
+    Returns:
+        Lowercase email if valid, None if input is None
+
+    Raises:
+        ValueError: If email format is invalid
+    """
+    if email is None:
+        return None
+    return validate_email_permissive(email)

--- a/api/app/users/api/user_dto.py
+++ b/api/app/users/api/user_dto.py
@@ -1,12 +1,22 @@
-from pydantic import BaseModel, EmailStr, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator, field_validator
 from typing import Optional, Any
 from datetime import datetime
 from uuid import UUID
 
+from app.shared.utils.validators import (
+    validate_email_permissive,
+    validate_email_optional,
+)
+
 
 class UserBase(BaseModel):
-    email: EmailStr
+    email: str
     full_name: Optional[str] = None
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        return validate_email_permissive(v)
 
 
 class UserCreate(UserBase):
@@ -14,11 +24,16 @@ class UserCreate(UserBase):
 
 
 class UserUpdate(BaseModel):
-    email: Optional[EmailStr] = None
+    email: Optional[str] = None
     full_name: Optional[str] = None
     password: Optional[str] = None
     is_active: Optional[bool] = None
     role: Optional[str] = None
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: Optional[str]) -> Optional[str]:
+        return validate_email_optional(v)
 
 
 class UserResponse(UserBase):


### PR DESCRIPTION
## Summary

- Replace Pydantic's strict `EmailStr` validator with a custom permissive validator
- Allows local/internal domains commonly used in corporate environments:
  - `.local`, `.localhost`, `.internal`, `.corp`, `.lan`, `.test`
- Create shared `validate_email_permissive` utility in `app/shared/utils/validators.py`
- Update setup, auth, and user DTOs to use the new validator

## Why

Pydantic's default `EmailStr` validator rejects domains like `.local` and `.localhost` with the error:
> "The part after the @-sign is a special-use or reserved name that cannot be used with email"

This is too restrictive for a self-hosted platform where organizations commonly use internal domains.

## Test plan

- [x] All 320 API tests pass
- [x] All 47 portal tests pass
- [x] Manual testing with `admin@example.local` and `admin@example.localhost`
- [x] Setup wizard flow works end-to-end
- [x] Login flow works end-to-end