### PR TITLE
fix: expose API port in production and add profile action for current user

### DIFF
--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -91,8 +91,8 @@ services:
       CORS_ALLOW_HEADERS: "Content-Type,Authorization,Accept,Origin,X-Requested-With"
       SKIP_SETUP: ${SKIP_SETUP:-false}
       TRON_SECRETS_KEY: ${TRON_SECRETS_KEY:-}
-    expose:
-      - "8000"
+    ports:
+      - "8000:8000"
     depends_on:
       api-migrate:
         condition: service_completed_successfully
@@ -113,7 +113,7 @@ services:
       - full
     environment:
       VITE_API_BASE_URL: ${API_URL:-/api}
-    expose:
+    ports:
       - "80"
     depends_on:
       - api

--- a/portal/src/pages/users/Users.tsx
+++ b/portal/src/pages/users/Users.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react'
-import { X, Trash2, Plus, Edit, Mail, UserCheck, UserX, Shield } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { X, Trash2, Plus, Edit, Mail, UserCheck, UserX, Shield, User as UserIcon } from 'lucide-react'
 import { useUsers, useCreateUser, useUpdateUser, useDeleteUser } from '../../features/users'
 import type { User, UserCreate } from '../../features/users'
 import { DataTable, Breadcrumbs, PageHeader } from '../../shared/components'
 import { useAuth } from '../../contexts/AuthContext'
 
 function Users() {
+  const navigate = useNavigate()
   const { user: currentUser } = useAuth()
   const [isOpen, setIsOpen] = useState(false)
   const [editingUser, setEditingUser] = useState<User | null>(null)
@@ -328,8 +330,16 @@ function Users() {
           actions={(user) => {
             const actions = []
 
-            // Do not allow editing/deleting/deactivating own user
-            if (user.uuid !== currentUser?.uuid) {
+            // For own user, only show "View Profile" action
+            if (user.uuid === currentUser?.uuid) {
+              actions.push({
+                label: 'View Profile',
+                icon: <UserIcon size={14} />,
+                onClick: () => navigate('/profile'),
+                variant: 'default' as const,
+              })
+            } else {
+              // For other users, show management actions
               actions.push({
                 label: user.is_active ? 'Deactivate' : 'Activate',
                 icon: user.is_active ? <UserX size={14} /> : <UserCheck size={14} />,


### PR DESCRIPTION
## Summary

- **docker-compose.prod.yaml**: Expose API port 8000 directly since Portal is compiled with `VITE_API_BASE_URL=http://localhost:8000`
- **Users.tsx**: Add "View Profile" action for the current user instead of showing an empty actions menu

## Why

1. **API Port**: The Portal Docker image is compiled with `http://localhost:8000` as the API URL. In production compose, the API was only using `expose` (internal only), causing the frontend to fail when trying to reach the API.

2. **User Actions**: When viewing the Users list, the current logged-in user had an empty actions menu (button did nothing). Now it shows "View Profile" to navigate to the profile page.

## Test plan

- [x] Local production environment working with exposed API port
- [x] Setup wizard works correctly
- [x] Login works correctly
- [x] "View Profile" action navigates to profile page