### PR TITLE
fix(ci): fix invalid Docker tag and Helm chart version extraction

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -70,7 +70,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -114,7 +114,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/update-helm-chart.yml
+++ b/.github/workflows/update-helm-chart.yml
@@ -35,7 +35,11 @@ jobs:
         id: version
         run: |
           if [ "${{ github.event_name }}" == "release" ]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
+            # Extract version from tags like api/v0.6.3 or portal/v0.6.3
+            RAW_REF="${GITHUB_REF#refs/tags/}"
+            # Remove prefix (api/ or portal/) and v prefix
+            VERSION=$(echo "$RAW_REF" | sed 's|^.*/v||')
+            echo "Raw ref: $RAW_REF -> Version: $VERSION"
           else
             VERSION="${{ github.event.inputs.version }}"
           fi


### PR DESCRIPTION
## Summary

Fixes two CI workflow errors:

### 1. Build and Push workflow - Invalid Docker tag

**Problem:** Tags were generated as `ghcr.io/grid-labs-tech/tron-portal:-8524af0` (starting with `-`) because `{{branch}}` was empty for PRs.

**Fix:** Changed `type=sha,prefix={{branch}}-` to `type=sha,prefix=sha-` for consistent tag naming.

### 2. Update Helm Chart workflow - Version extraction failure

**Problem:** The workflow expected tags like `v0.6.3` but we use `api/v0.6.3` or `portal/v0.6.3`. The sed command failed because the version contained `/` characters.

**Fix:** Updated version extraction to properly parse tags like `api/v0.6.3` → `0.6.3`.

## Test plan

- [ ] PR build workflow passes without invalid tag errors
- [ ] After merge, release workflow correctly updates Helm chart