### PR TITLE
fix(ci): add helm dependency update before packaging

### DIFF
--- a/.github/workflows/update-helm-chart.yml
+++ b/.github/workflows/update-helm-chart.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Package chart
         working-directory: charts/tron
         run: |
+          helm dependency update
           helm package .
           helm repo index . --url https://grid-labs-tech.github.io/charts
 


### PR DESCRIPTION
Add `helm dependency update` before `helm package` to download required dependencies (postgresql).