### PR TITLE
fix(ci): separate SARIF uploads with distinct categories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,12 +133,19 @@ jobs:
           output: 'trivy-portal-results.sarif'
           severity: 'CRITICAL,HIGH'
 
-      - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v3
+      - name: Upload Trivy scan results (API)
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
-          sarif_file: '.'
-          category: 'container-scanning'
+          sarif_file: 'trivy-api-results.sarif'
+          category: 'container-scanning-api'
+
+      - name: Upload Trivy scan results (Portal)
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: 'trivy-portal-results.sarif'
+          category: 'container-scanning-portal'
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
## Summary
- Split the combined Trivy SARIF upload into two separate uploads with distinct categories (api and portal)
- Fix the CodeQL Action error that no longer supports multiple SARIF runs with the same category
- Updated CodeQL Action from v3 to v4 (v3 will be deprecated in Dec 2026)

## Related
This fixes the failed release workflow for v0.7.0. The release was created manually after the images were successfully published.

## Test plan
- [ ] Next release should complete successfully without SARIF upload errors