### PR TITLE
fix: docker-compose doens't work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-# Use docker-compose or docker compose based on availability
-DOCKER_COMPOSE := $(shell command -v docker-compose 2>/dev/null || echo "docker compose")
+DOCKER_COMPOSE := docker compose
 COMPOSE_FILE := docker/docker-compose.yaml
 COMPOSE_TEST_FILE := docker/docker-compose.test.yaml
 COMPOSE_CLUSTER2_FILE := docker/docker-compose.cluster2.yaml


### PR DESCRIPTION
## Description

The docker-compose command (docker compose v1) doesn't work upon running `make start`. 

And it shouldn't be supported, even when available at local development environment. As is, the `make` command is selecting the deprecated _docker-compose_ (if available), but the presented `docker-compose.yml` file isn't supported by it (mainly because the variable interpolation).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Component Affected

- [x] Other: local development